### PR TITLE
Dealcluster changed from pairs to coins

### DIFF
--- a/altrank.py
+++ b/altrank.py
@@ -216,7 +216,7 @@ def lunarcrush_pairs(cfg, thebot):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot["id"], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(
@@ -225,7 +225,8 @@ def lunarcrush_pairs(cfg, thebot):
         )
         return
 
-    # Lower the number of max deals if not enough new pairs and change allowed, change back to original if possible
+    # Lower the number of max deals if not enough new pairs and change allowed and
+    # change back to original if possible
     if allowmaxdealchange:
         if len(newpairs) < thebot["max_active_deals"]:
             newmaxdeals = len(newpairs)

--- a/botassistexplorer.py
+++ b/botassistexplorer.py
@@ -91,7 +91,7 @@ def botassist_pairs(thebot, botassistdata):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -149,7 +149,7 @@ def coinmarketcap_pairs(thebot, cmcdata):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(

--- a/dealcluster.py
+++ b/dealcluster.py
@@ -373,8 +373,9 @@ def write_cluster_exclude_files(cluster_id, bot_list):
 
     if sharedir is not None:
         clusterdisabledcoins = cursor.execute(
-            f"SELECT DISTINCT(coin) FROM bot_pairs "
-            f"WHERE clusterid = '{cluster_id}' AND enabled = {0}"
+            f"SELECT coin FROM cluster_coins "
+            f"WHERE clusterid = '{cluster_id}' AND "
+            f"number_active >= {int(config.get(cluster_id, 'max-same-deals'))}"
         ).fetchall()
 
         if clusterdisabledcoins:

--- a/dealcluster.py
+++ b/dealcluster.py
@@ -361,7 +361,7 @@ def update_bot_config(cluster_id, thebot):
 
     if botenabledpairs:
         enabledpairlist = [row[0] for row in botenabledpairs]
-        #set_threecommas_bot_pairs(logger, api, thebot, enabledpairlist, False, False)
+        set_threecommas_bot_pairs(logger, api, thebot, enabledpairlist, False, False)
     else:
         logger.warning(
             f"Failed to get enabled pairs for bot {bot_id}"
@@ -373,7 +373,7 @@ def write_cluster_exclude_files(cluster_id, bot_list):
 
     if sharedir is not None:
         clusterdisabledcoins = cursor.execute(
-            f"SELECT coin FROM bot_pairs "
+            f"SELECT DISTINCT(coin) FROM bot_pairs "
             f"WHERE clusterid = '{cluster_id}' AND enabled = {0}"
         ).fetchall()
 

--- a/galaxyscore.py
+++ b/galaxyscore.py
@@ -216,7 +216,7 @@ def lunarcrush_pairs(cfg, thebot):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot["id"], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(
@@ -225,7 +225,8 @@ def lunarcrush_pairs(cfg, thebot):
         )
         return
 
-    # Lower the number of max deals if not enough new pairs and change allowed, change back to original if possible
+    # Lower the number of max deals if not enough new pairs and change allowed and
+    # change back to original if possible
     if allowmaxdealchange:
         if len(newpairs) < thebot["max_active_deals"]:
             newmaxdeals = len(newpairs)

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -233,22 +233,25 @@ def get_botassist_data(logger, botassistlist, start_number, limit):
     return pairs
 
 
-def remove_excluded_pairs(logger, share_dir, bot_id, newpairs):
+def remove_excluded_pairs(logger, share_dir, bot_id, marketcode, base, newpairs):
     """Remove pairs which are excluded by other script(s)."""
 
-    excludedpairs = load_bot_excluded_pairs(logger, share_dir, bot_id, PAIREXCLUDE_EXT)
-    if excludedpairs:
+    excludedcoins = load_bot_excluded_coins(logger, share_dir, bot_id, PAIREXCLUDE_EXT)
+    if excludedcoins:
         logger.info(
-            f"Removing the following pair(s) for bot {bot_id}: {excludedpairs}"
+            f"Removing the following coin(s) for bot {bot_id}: {excludedcoins}"
         )
 
-        for pair in excludedpairs:
+        for coin in excludedcoins:
+            # Construct pair based on bot settings and marketcode
+            # (BTC stays BTC, but USDT can become BUSD)
+            pair = format_pair(logger, marketcode, base, coin)
             if newpairs.count(pair) > 0:
                 newpairs.remove(pair)
 
 
-def load_bot_excluded_pairs(logger, share_dir, bot_id, extension):
-    """Load excluded pairs from file, for the specified bot"""
+def load_bot_excluded_coins(logger, share_dir, bot_id, extension):
+    """Load excluded coins from file, for the specified bot"""
 
     excludedlist = []
     excludefilename = f"{share_dir}/{bot_id}.{extension}"
@@ -258,12 +261,12 @@ def load_bot_excluded_pairs(logger, share_dir, bot_id, extension):
             excludedlist = file.read().splitlines()
         if excludedlist:
             logger.info(
-                "Reading exclude file '%s' OK (%s pairs)"
+                "Reading exclude file '%s' OK (%s coins)"
                 % (excludefilename, len(excludedlist))
             )
     except FileNotFoundError:
         logger.info(
-            "Exclude file (%s) not found for bot '%s'; no pairs to exclude."
+            "Exclude file (%s) not found for bot '%s'; no coins to exclude."
             % (excludefilename, bot_id)
         )
 

--- a/volatility.py
+++ b/volatility.py
@@ -157,7 +157,7 @@ def lunarcrush_pairs(thebot):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(


### PR DESCRIPTION
Working on pairs is good, but if you want to mix BTC and BUSD bots in the same cluster it doesn't work anymore. So cluster needs to operate on the coin itself so that BUSD_ETH is counted the same as BTC_ETH when only one deal is allowed (for example)